### PR TITLE
Update handling of splashDuration and displaySaverTimeout

### DIFF
--- a/src/Pages/DisplayConfig.js
+++ b/src/Pages/DisplayConfig.js
@@ -154,8 +154,8 @@ const schema = yup.object().shape({
 			buttonPadding: yup.number().required().min(0).max(20).label('Button Padding')
 		})
 	}),
-	splashDuration: yup.number().required().oneOf(SPLASH_DURATION_CHOICES.map(o => o.value)).label('Splash Duration'),
-	displaySaverTimeout: yup.number().required().oneOf(DISPLAY_SAVER_TIMEOUT_CHOICES.map(o => o.value)).label('Display Saver'),
+	splashDuration: yup.number().required().min(0).label('Splash Duration'),
+	displaySaverTimeout: yup.number().required().min(0).label('Display Saver'),
 });
 
 const FormContext = () => {
@@ -520,30 +520,28 @@ export default function DisplayConfigPage() {
 							</Col>
 						</Row>}
 						<Row className="mb-3">
-							<FormSelect
-									label="Splash Duration"
-									name="splashDuration"
-									className="form-select-sm"
-									groupClassName="col-sm-3 mb-3"
-									value={values.splashDuration}
-									error={errors.splashDuration}
-									isInvalid={errors.splashDuration}
-									onChange={handleChange}
-								>
-									{SPLASH_DURATION_CHOICES.map((o, i) => <option key={`splashDuration-option-${i}`} value={o.value}>{o.label}</option>)}
-							</FormSelect>
-							<FormSelect
-									label="Display Saver Timeout"
-									name="displaySaverTimeout"
-									className="form-select-sm"
-									groupClassName="col-sm-3 mb-3"
-									value={values.displaySaverTimeout}
-									error={errors.displaySaverTimeout}
-									isInvalid={errors.displaySaverTimeout}
-									onChange={handleChange}
-								>
-									{DISPLAY_SAVER_TIMEOUT_CHOICES.map((o, i) => <option key={`displaySaverTimeout-option-${i}`} value={o.value}>{o.label}</option>)}
-							</FormSelect>
+							<FormControl type="number"
+								label="Splash Duration (seconds, 0 for Always On)"
+								name="splashDuration"
+								className="form-select-sm"
+								groupClassName="col-sm-3 mb-3"
+								value={values.splashDuration}
+								error={errors.splashDuration}
+								isInvalid={errors.splashDuration}
+								onChange={handleChange}
+								min={0}
+							/>
+							<FormControl type="number"
+								label="Display Saver Timeout (minutes)"
+								name="displaySaverTimeout"
+								className="form-select-sm"
+								groupClassName="col-sm-3 mb-3"
+								value={values.displaySaverTimeout}
+								error={errors.displaySaverTimeout}
+								isInvalid={errors.displaySaverTimeout}
+								onChange={handleChange}
+								min={0}
+							/>
 						</Row>
 						<Row>
 							<Field name="splashImage">

--- a/src/Services/WebApi.js
+++ b/src/Services/WebApi.js
@@ -35,6 +35,8 @@ async function getDisplayOptions() {
 		.then((response) => {
 			if (response.data.i2cAddress)
 				response.data.i2cAddress = '0x' + response.data.i2cAddress.toString(16);
+			response.data.splashDuration = response.data.splashDuration / 1000; // milliseconds to seconds 
+			response.data.displaySaverTimeout = response.data.displaySaverTimeout / 60000; // milliseconds to minutes 
 
 			return response.data;
 		})
@@ -47,6 +49,8 @@ async function setDisplayOptions(options, isPreview) {
 	newOptions.buttonLayout = parseInt(options.buttonLayout);
 	newOptions.buttonLayoutRight = parseInt(options.buttonLayoutRight);
 	newOptions.splashMode = parseInt(options.splashMode);
+	newOptions.splashDuration = parseInt(options.splashDuration) * 1000; // seconds to milliseconds
+	newOptions.displaySaverTimeout = parseInt(options.displaySaverTimeout) * 60000; // minutes to milliseconds
 	newOptions.splashChoice = parseInt(options.splashChoice);
 	newOptions.buttonLayoutCustomOptions.params.layout = parseInt(options.buttonLayoutCustomOptions.params.layout);
 	newOptions.buttonLayoutCustomOptions.paramsRight.layout = parseInt(options.buttonLayoutCustomOptions.paramsRight.layout);


### PR DESCRIPTION
For PR: https://github.com/OpenStickCommunity/GP2040-CE/pull/121 which addresses issue: https://github.com/OpenStickCommunity/GP2040-CE/issues/120.

Just changed the drop-downs to textbox as suggested. Also, transformed values to make it simple on the board side.