### PR TITLE
await webApi for success/error message to show correctly

### DIFF
--- a/src/Pages/AddonsConfigPage.js
+++ b/src/Pages/AddonsConfigPage.js
@@ -194,9 +194,9 @@ const verifyAndSavePS4 = async () => {
 					return btoa(String.fromCharCode.apply(null, arr));
 				}
 
-				const sendPS4Chunks = (chunks) => {
+				const sendPS4Chunks = async (chunks) => {
 					for ( var i in chunks ) {
-						if ( WebApi.setPS4Options(chunks[i]) === false ) {
+						if (await WebApi.setPS4Options(chunks[i]) === false ) {
 							return false;
 						}
 					}
@@ -521,7 +521,7 @@ export default function AddonsConfigPage() {
 	const [saveMessage, setSaveMessage] = useState('');
 
 	const onSuccess = async (values) => {
-		const success = WebApi.setAddonsOptions(values);
+		const success = await WebApi.setAddonsOptions(values);
 		setSaveMessage(success ? 'Saved! Please Restart Your Device' : 'Unable to Save');
 	};
 

--- a/src/Pages/LEDConfigPage.js
+++ b/src/Pages/LEDConfigPage.js
@@ -125,7 +125,7 @@ export default function LEDConfigPage() {
 	};
 
 	const onSuccess = async (values) => {
-		const success = WebApi.setLedOptions(values);
+		const success = await WebApi.setLedOptions(values);
 		setSaveMessage(success ? 'Saved! Please Restart Your Device' : 'Unable to Save');
 	};
 

--- a/src/Pages/SettingsPage.js
+++ b/src/Pages/SettingsPage.js
@@ -99,7 +99,7 @@ export default function SettingsPage() {
 	const [saveMessage, setSaveMessage] = useState('');
 
 	const onSuccess = async (values) => {
-		const success = WebApi.setGamepadOptions(values);
+		const success = await WebApi.setGamepadOptions(values);
 		setSaveMessage(success ? 'Saved! Please Restart Your Device' : 'Unable to Save');
 	};
 


### PR DESCRIPTION
<img width="875" alt="Skärmavbild 2023-05-02 kl  00 39 21" src="https://user-images.githubusercontent.com/5345892/235549587-075f6357-f69b-45e6-b8ec-973b8ad6b86b.png">

awaiting the webApi to not give false positive when showing message
