### PR TITLE
Custom LEDs - Add save color and apply gradient options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "bootstrap": "^5.2.3",
         "crypto-js": "^4.1.1",
         "formik": "^2.2.9",
+        "javascript-color-gradient": "^2.4.4",
         "jsbn": "^1.1.0",
         "jsencrypt": "^3.3.2",
         "lodash": "^4.17.21",
@@ -9926,6 +9927,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/javascript-color-gradient": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/javascript-color-gradient/-/javascript-color-gradient-2.4.4.tgz",
+      "integrity": "sha512-kbt3Y1eltW4X789P1eQzCUEB5X7hFmLNpQT4bgDFMtj/cW2v+j8ms/rLSR7jndZUAP6yya4vyeZK6bRqh6yClA=="
     },
     "node_modules/jest": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "bootstrap": "^5.2.3",
     "crypto-js": "^4.1.1",
     "formik": "^2.2.9",
+    "javascript-color-gradient": "^2.4.4",
     "jsbn": "^1.1.0",
     "jsencrypt": "^3.3.2",
     "lodash": "^4.17.21",

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
-import { AppContext } from './Contexts/AppContext';
+import { AppContextProvider } from './Contexts/AppContext';
 import Navigation from './Components/Navigation'
 
 import HomePage from './Pages/HomePage'
@@ -19,15 +19,8 @@ import { loadButtonLabels } from './Services/Storage';
 import './App.scss';
 
 const App = () => {
-	const [buttonLabels, setButtonLabels] = useState(loadButtonLabels() ?? 'gp2040');
-
-	const appData = {
-		buttonLabels,
-		setButtonLabels,
-	};
-
 	return (
-		<AppContext.Provider value={appData}>
+		<AppContextProvider>
 			<Router>
 				<Navigation />
 				<div className="container-fluid body-content">
@@ -46,7 +39,7 @@ const App = () => {
 					</Routes>
 				</div>
 			</Router>
-		</AppContext.Provider>
+		</AppContextProvider>
 	);
 }
 

--- a/src/Contexts/AppContext.js
+++ b/src/Contexts/AppContext.js
@@ -1,7 +1,31 @@
-import { createContext } from 'react';
+import React, { createContext, useState } from 'react';
 
-export const defaultAppData = {
-	buttonLabels: 'gp2040',
+export const AppContext = createContext(null);
+
+export const AppContextProvider = ({ children, ...props }) => {
+	const [buttonLabels, _setButtonLabels] = useState(localStorage.getItem('buttonLabels') || 'gp2040');
+	const setButtonLabels = (buttonLabels) => {
+		localStorage.setItem('buttonLabels', buttonLabels);
+		_setButtonLabels(buttonLabels);
+	};
+
+	const [savedColors, _setSavedColors] = useState(localStorage.getItem('savedColors') ? localStorage.getItem('savedColors').split(',') : []);
+	const setSavedColors = (savedColors) => {
+		localStorage.setItem('savedColors', savedColors);
+		_setSavedColors(savedColors);
+	};
+
+	return (
+		<AppContext.Provider
+			{...props}
+			value={{
+				buttonLabels,
+				savedColors,
+				setButtonLabels,
+				setSavedColors,
+			}}
+		>
+			{children}
+		</AppContext.Provider>
+	);
 };
-
-export const AppContext = createContext(defaultAppData);

--- a/src/Data/Buttons.js
+++ b/src/Data/Buttons.js
@@ -135,3 +135,34 @@ export const BUTTONS = {
 
 export const AUX_BUTTONS = [ 'S1', 'S2', 'L3', 'R3', 'A1', 'A2' ];
 export const MAIN_BUTTONS = [ 'Up', 'Down', 'Left', 'Right', 'B1', 'B2', 'B3', 'B4', 'L1', 'R1', 'L2', 'R2' ];
+
+export const STICK_LAYOUT = [
+	[null, 'Left', null],
+	['Up', null, 'Down'],
+	[null, 'Right', null],
+	['B3', null, 'B1'],
+	['B4', null, 'B2'],
+	['R1', null, 'R2'],
+	['L1', null, 'L2'],
+];
+
+export const STICKLESS_LAYOUT = [
+	['Left', null, null],
+	['Down', null, null],
+	['Right', null, null],
+	[null, 'Up', null],
+	['B3', 'B1', null],
+	['B4', 'B2', null],
+	['R1', 'R2', null],
+	['L1', 'L2', null],
+];
+
+export const KEYBOARD_LAYOUT = [
+	[null, 'Left'],
+	['Up', 'Down'],
+	[null, 'Right'],
+	['B3', 'B1'],
+	['B4', 'B2'],
+	['R1', 'R2'],
+	['L1', 'L2'],
+];

--- a/src/Pages/CustomThemePage.js
+++ b/src/Pages/CustomThemePage.js
@@ -169,7 +169,8 @@ const CustomThemePage = () => {
 	};
 
 	const saveCurrentColor = () => {
-		if (presetColors.filter(c => c.color.toLowerCase() === selectedColor.hex.toLowerCase()).length > 0)
+		const color = selectedColor.hex;
+		if (!color || presetColors.filter(c => c.color === color).length > 0)
 			return;
 
 		const newColors = [...savedColors];

--- a/src/Pages/CustomThemePage.js
+++ b/src/Pages/CustomThemePage.js
@@ -3,6 +3,7 @@ import Button from 'react-bootstrap/Button';
 import ButtonGroup from 'react-bootstrap/ButtonGroup';
 import Col from 'react-bootstrap/Col';
 import Container from 'react-bootstrap/Container';
+import Fade from 'react-bootstrap/Fade';
 import Form from 'react-bootstrap/Form';
 import FormCheck from 'react-bootstrap/FormCheck';
 import Modal from 'react-bootstrap/Modal';
@@ -86,12 +87,13 @@ const CustomThemePage = () => {
 	const [selectedColor, setSelectedColor] = useState('#000000');
 	const [hasCustomTheme, setHasCustomTheme] = useState(false);
 	const [customTheme, setCustomTheme] = useState({ ...defaultCustomTheme });
-	const [ledOverlayTarget, setLedOverlayTarget] = useState(null);
+	const [ledOverlayTarget, setLedOverlayTarget] = useState(document.body);
+	const [pickerVisible, setPickerVisible] = useState(false);
 	const [modalVisible, setModalVisible] = useState(false);
 
+	console.log('toggle after', pickerVisible, selectedButton);
+
 	const confirmClearAll = () => {
-		setLedOverlayTarget(null);
-		setSelectedButton(null);
 		setSelectedColor(null);
 
 		// Reset all custom LEDs
@@ -126,16 +128,17 @@ const CustomThemePage = () => {
 	};
 
 	const toggleSelectedButton = (e, buttonName) => {
+		console.log('toggle before', pickerVisible, selectedButton, buttonName);
 		e.stopPropagation();
 		if (selectedButton === buttonName) {
-			setSelectedButton(null);
-			setLedOverlayTarget(null);
+			setPickerVisible(false);
 		}
 		else {
 			setLedOverlayTarget(e.target);
 			setSelectedButton(buttonName);
 			setSelectedColor(buttonName === 'ALL' ? '#000000' : customTheme[buttonName].normal);
 			setPickerType({ type: 'normal', button: buttonName });
+			setPickerVisible(true);
 		}
 	};
 
@@ -233,12 +236,11 @@ const CustomThemePage = () => {
 					</>
 				}
 				<Overlay
-					show={!!selectedButton}
+					show={pickerVisible}
 					target={ledOverlayTarget}
 					placement={selectedButton === 'ALL' ? 'top' : 'bottom'}
 					container={this}
 					containerPadding={20}
-					transition={null}
 				>
 					<Popover onClick={(e) => e.stopPropagation()}>
 						<Container className="led-color-picker">

--- a/src/Services/Utilities.js
+++ b/src/Services/Utilities.js
@@ -32,8 +32,8 @@ const rgbArrayToHex = (values) => {
 };
 
 export {
-	intToHex,
 	hexToInt,
+	intToHex,
 	rgbArrayToHex,
 	rgbIntToHex,
 };

--- a/src/Services/Utilities.js
+++ b/src/Services/Utilities.js
@@ -5,7 +5,7 @@ const hexToInt = (hex) => {
 
 // Convert a number to hex
 const intToHex = (d) => {
-	return ("0"+(Number(d).toString(16))).slice(-2).toUpperCase();
+	return ("0"+(Number(d).toString(16))).slice(-2).toLowerCase();
 };
 
 // Convert a 32-bit ARGB value to hex format (no # prefix)

--- a/src/index.scss
+++ b/src/index.scss
@@ -62,3 +62,11 @@ input.form-control {
 	}
 }
 
+.button-group {
+	display: flex;
+	justify-content: flex-start;
+
+	button:not(:first-child) {
+		margin-left: 10px;
+	}
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -53,7 +53,7 @@ input.form-control {
 }
 
 .popover {
-	position: absolute;
+	position: fixed !important;
 	z-index: 2;
 
 	.cover {


### PR DESCRIPTION
These were a suggestions by one of the 0.7.1 beta testers.

Features:

* Ability to save and delete custom colors (cannot delete stock LED colors from firmware)
* Saved colors are persisted to Local Storage
* Added `Set Gradient` and `Set Pressed Gradient` buttons to apply a horizontal gradient across the action buttons
* Gradient applied properly based on the selected `Preview Layout` (aka stickless blends Up between Right and B3/B1 colors)
* Gradient selection is not persisted at the moment, but can be added later if needed